### PR TITLE
Added parameter to avoid using ranges when creating tspans for mobilesafari; Added support for CSS transforms.

### DIFF
--- a/src/element.ts
+++ b/src/element.ts
@@ -114,21 +114,17 @@ export function handleElement(element: Element, context: Readonly<TraversalConte
 			svgContainer.setAttribute('opacity', styles.opacity)
 		}
 
+		// CSS Transforms to SVG transforms
 		if (styles.transform && styles.transform !== 'none') {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const anyelement: any = element
+			const htmlelement: HTMLElement = element as HTMLElement
 			const left: number = context.options.captureArea.left ? context.options.captureArea.left : 0
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-			const offsetLeft: number = anyelement.offsetLeft as number
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-			const offsetWidth: number = anyelement.offsetWidth as number
+			const offsetLeft: number = htmlelement.offsetLeft
+			const offsetWidth: number = htmlelement.offsetWidth
 			const centerx = left + offsetLeft + offsetWidth / 2
 
 			const top: number = context.options.captureArea.top ? context.options.captureArea.top : 0
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-			const offsetTop: number = anyelement.offsetTop as number
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-			const offsetHeight: number = anyelement.offsetHeight as number
+			const offsetTop: number = htmlelement.offsetTop
+			const offsetHeight: number = htmlelement.offsetHeight
 			const centery = top + offsetTop + offsetHeight / 2
 
 			const strtransform = `translate(${centerx} ${centery}) ${

--- a/src/element.ts
+++ b/src/element.ts
@@ -114,6 +114,29 @@ export function handleElement(element: Element, context: Readonly<TraversalConte
 			svgContainer.setAttribute('opacity', styles.opacity)
 		}
 
+		if (styles.transform && styles.transform !== 'none') {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const anyelement: any = element
+			const left: number = context.options.captureArea.left ? context.options.captureArea.left : 0
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			const offsetLeft: number = anyelement.offsetLeft as number
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			const offsetWidth: number = anyelement.offsetWidth as number
+			const centerx = left + offsetLeft + offsetWidth / 2
+
+			const top: number = context.options.captureArea.top ? context.options.captureArea.top : 0
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			const offsetTop: number = anyelement.offsetTop as number
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			const offsetHeight: number = anyelement.offsetHeight as number
+			const centery = top + offsetTop + offsetHeight / 2
+
+			const strtransform = `translate(${centerx} ${centery}) ${
+				styles.transform
+			} translate(${-centerx} ${-centery})`
+			svgContainer.setAttribute('transform', strtransform)
+		}
+
 		// Accessibility
 		for (const [name, value] of getAccessibilityAttributes(element, context)) {
 			svgContainer.setAttribute(name, value)

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export function elementToSVG(element: Element, options?: DomToSvgOptions): XMLDo
 		options: {
 			captureArea: options?.captureArea ?? element.getBoundingClientRect(),
 			keepLinks: options?.keepLinks !== false,
+			avoidTextSelection: options ? !!options.avoidTextSelection : false
 		},
 	})
 

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -60,6 +60,7 @@ export async function inlineResources(element: Element): Promise<void> {
 								// SVGs embedded through <img> are never interactive.
 								keepLinks: false,
 								captureArea: svgRoot.viewBox.baseVal,
+								avoidTextSelection: false
 							},
 						})
 

--- a/src/text.ts
+++ b/src/text.ts
@@ -55,8 +55,10 @@ export function handleTextNode(textNode: Text, context: TraversalContext): void 
 			try {
 				selection.removeAllRanges()
 				selection.addRange(lineRange)
-				if(context.options.avoidTextSelection) {
+				if (context.options.avoidTextSelection) {
 					textSpan.textContent = textNode.textContent
+						? textNode.textContent.slice(lineRange.startOffset, lineRange.endOffset)
+						: textNode.textContent
 				} else {
 					textSpan.textContent = selection
 						.toString()

--- a/src/text.ts
+++ b/src/text.ts
@@ -55,12 +55,16 @@ export function handleTextNode(textNode: Text, context: TraversalContext): void 
 			try {
 				selection.removeAllRanges()
 				selection.addRange(lineRange)
-				textSpan.textContent = selection
-					.toString()
-					// SVG does not support tabs in text. Tabs get rendered as one space character. Convert the
-					// tabs to spaces according to tab-size instead.
-					// Ideally we would keep the tab and create offset tspans.
-					.replace(/\t/g, ' '.repeat(tabSize))
+				if(context.options.avoidTextSelection) {
+					textSpan.textContent = textNode.textContent
+				} else {
+					textSpan.textContent = selection
+						.toString()
+						// SVG does not support tabs in text. Tabs get rendered as one space character. Convert the
+						// tabs to spaces according to tab-size instead.
+						// Ideally we would keep the tab and create offset tspans.
+						.replace(/\t/g, ' '.repeat(tabSize))
+				}
 			} finally {
 				parentElement.style.userSelect = previousUserSelect
 				selection.removeAllRanges()

--- a/src/traversal.ts
+++ b/src/traversal.ts
@@ -16,6 +16,14 @@ export interface DomToSvgOptions {
 	 * @default true
 	 */
 	keepLinks?: boolean
+
+	/**
+	 * Whether to use text selection to fill tspans or use textContent (different whitespace handling).
+	 * textContent works in mobile iOS browsers
+	 *
+	 * @default false
+	 */
+	avoidTextSelection?: boolean
 }
 
 export interface TraversalContext {


### PR DESCRIPTION
When creating tspans on mobile Safari using the ranges, the output comes out empty. Using text content + string manipulations yields correct results (tested on an iPhone SE and an iPad). The change doesn't seem to affect behaviour on a desktop.

CSS Transforms were completely ignored by the library, as far as I'm aware. As the HTML element contains CSS transforms, and SVG transforms operate on a different coordinate system, I had to convert CSS transforms to SVG transforms.
To do this, I've computed the `transform` attribute on the final svg element by:
- Moving the element so it's center is positioned in svg coordinates 0,0
- Applying the computed style transformation matrix
- Moving the element back to it's position

This method should work correctly with all kinds of SVG transformations, but I've only tested a rotation around the center, as that was my use case.