### PR TITLE
fix(inline.ts): use xlink:href additionally to href in img

### DIFF
--- a/src/inline.ts
+++ b/src/inline.ts
@@ -23,8 +23,11 @@ export async function inlineResources(element: Element): Promise<void> {
 		...[...element.children].map(inlineResources),
 		(async () => {
 			if (isSVGImageElement(element)) {
-				const blob = await withTimeout(10000, `Timeout fetching ${element.href.baseVal}`, () =>
-					fetchResource(element.href.baseVal)
+				const elementHref = element.getAttribute('href') || element.getAttribute('xlink:href');
+				assert(elementHref, "Expected <image> element to have an href or xlink:href attribute");
+
+				const blob = await withTimeout(10000, `Timeout fetching ${elementHref}`, () =>
+					fetchResource(elementHref)
 				)
 				if (blob.type === 'image/svg+xml') {
 					// If the image is an SVG, inline it into the output SVG.


### PR DESCRIPTION
Hey 👋

This pull request aim to resolve an issue about the `inlineResources` function.

When we try to use the `inlineResources` function, an error is throw. The error is due to an empty URL given to the `fetchResource` function. The URL is empty because the `inlineResources` function try to find the href of an image, but it appears that the href of the image element is changed before to an xlink:href attribute.

With this simple workaround I propose, we should be able to retrieve URL from the *href* or *xlink:href* attribute.

Edit: this should resolve #170 

Regards, 
Valentin